### PR TITLE
Update dependency from mypy-lang to mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='Mypy static type checker plugin for Pytest',
     long_description=read('README.rst'),
     py_modules=['pytest_mypy'],
-    install_requires=['pytest>=2.9.2', 'mypy-lang>=0.4.5'],
+    install_requires=['pytest>=2.9.2', 'mypy>=0.470'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',


### PR DESCRIPTION
When trying to use a development snapshot of `mypy` (through `pip install git+https://github.com/python/mypy.git\#egg\=mypy`), the current `setup.py` is ignoring the existing `mypy` installation because it doesn't match `mypy-lang`, making such use impossible.

Apparently mypy's maintainers managed to get access to `mypy` in PyPI, and their `setup.py` now builds using this very name.

This fix consists of dropping the dependency on `mypy-lang` and adding a new one on `mypy` requiring version `0.470` or newer, which is the earliest version available on  PyPI for this newly named package.