### PR TITLE
Only depend on mypy.api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 sudo: false
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='Mypy static type checker plugin for Pytest',
     long_description=read('README.rst'),
     py_modules=['pytest_mypy'],
-    install_requires=['pytest>=2.9.2', 'mypy>=0.470'],
+    install_requires=['pytest>=2.9.2', 'mypy~=0.570'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py33,py34,py35,flake8
+envlist = py34,py35,py36,flake8
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Fixes #6 

> I think we should strongly discourage such use of interfaces internal to mypy. The only public APIs are the command line and the mypy.api module.
https://github.com/python/mypy/issues/4681#issuecomment-371037599