### PR TITLE
Revert "Call mypy with newly added parameter `flush_errors`"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 sudo: false
 language: python
 python:
+  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/pytest_mypy.py
+++ b/pytest_mypy.py
@@ -55,7 +55,7 @@ class MypyItem(pytest.Item, pytest.File):
         sources, options = mypy.main.process_options(mypy_argv)
 
         try:
-            res = mypy.main.type_check_only(sources, None, options, flush_errors=None)
+            res = mypy.main.type_check_only(sources, None, options)
             errors = res.errors
         except mypy.errors.CompileError as e:
             errors = e.messages

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='Mypy static type checker plugin for Pytest',
     long_description=read('README.rst'),
     py_modules=['pytest_mypy'],
-    install_requires=['pytest>=2.9.2', 'mypy>=0.570'],
+    install_requires=['pytest>=2.9.2', 'mypy>=0.470'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',
@@ -31,6 +31,7 @@ setup(
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py34,py35,py36,flake8
+envlist = py33,py34,py35,flake8
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Reverts dbader/pytest-mypy#7

#8 is better because we'll start using mypy's public API.