### PR TITLE
Invoke mypy with --incremental

### DIFF
--- a/pytest_mypy.py
+++ b/pytest_mypy.py
@@ -45,6 +45,7 @@ class MypyItem(pytest.Item, pytest.File):
         # own options parsing.
         mypy_argv = [
             str(self.path),
+            '--incremental',
             # TODO: This is where we'd tack on other mypy options
             #       from the pytest config.
             #       Or maybe we'll just rely on mypy.ini being present?


### PR DESCRIPTION
Closes #4 

I tested with https://github.com/petr-muller/vtes.

Control:
```
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ rm -rf .pytest_cache/ .mypy_cache/
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ time (mypy . ; pytest)
========================================== test session starts ==========================================
platform linux -- Python 3.6.5rc1, pytest-3.4.2, py-1.5.2, pluggy-0.6.0
...
======================================= 52 passed in 9.40 seconds =======================================

real	0m11.420s
user	0m10.489s
sys	0m0.866s
```

Before:
```
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ rm -rf .pytest_cache/ .mypy_cache/
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ time pytest --mypy
========================================== test session starts ==========================================
platform linux -- Python 3.6.5rc1, pytest-3.4.2, py-1.5.2, pluggy-0.6.0
...
====================================== 63 passed in 21.45 seconds =======================================

real	0m23.068s
user	0m21.682s
sys	0m1.082s
```
After:
```
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ rm -rf .pytest_cache/ .mypy_cache/
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ time pytest --mypy
========================================== test session starts ==========================================
platform linux -- Python 3.6.5rc1, pytest-3.4.2, py-1.5.2, pluggy-0.6.0
...
====================================== 63 passed in 12.35 seconds =======================================

real	0m13.717s
user	0m12.767s
sys	0m0.897s
(vtes-S40RGN8u) david@kahuna:~/Projects/vtes $ time pytest --mypy
========================================== test session starts ==========================================
platform linux -- Python 3.6.5rc1, pytest-3.4.2, py-1.5.2, pluggy-0.6.0
...
======================================= 63 passed in 9.04 seconds =======================================

real	0m10.167s
user	0m9.252s
sys	0m0.844s
```