### PR TITLE
Define a header for the test report

### DIFF
--- a/pytest_mypy.py
+++ b/pytest_mypy.py
@@ -34,12 +34,14 @@ class MypyItem(pytest.Item, pytest.File):
         super().__init__(path, parent)
         self.path = path
 
+    def reportinfo(self):
+        """Produce a heading for the test report."""
+        return self.fspath, None, ' '.join(['mypy', self.name])
+
     def runtest(self):
         """
         Run mypy on the given file.
         """
-        # TODO: This should be hidden behind a debug / verbose flag.
-        print('Running mypy on', self.path)
 
         # Construct a fake command line argv and let mypy do its
         # own options parsing.


### PR DESCRIPTION
Fixes #14 

Before:
```
___________________________________________________  ____________________________________________________
tests/conftest.py:8: error: No library stub file for module 'pytest'
tests/conftest.py:8: note: (Stub files are from https://github.com/python/typeshed)
tests/conftest.py:10: error: Cannot find module named 'backlog'
tests/conftest.py:10: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)

----------------------------------------- Captured stdout call ------------------------------------------
Running mypy on /home/david/Projects/backlog/tests/conftest.py
```

After:
```
________________________________________ mypy tests/conftest.py _________________________________________
tests/conftest.py:8: error: No library stub file for module 'pytest'
tests/conftest.py:8: note: (Stub files are from https://github.com/python/typeshed)
tests/conftest.py:10: error: Cannot find module named 'backlog'
tests/conftest.py:10: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)

```

Note that the format is also the command to run to reproduce the output:
```
$ mypy tests/conftest.py
tests/conftest.py:8: error: No library stub file for module 'pytest'
tests/conftest.py:8: note: (Stub files are from https://github.com/python/typeshed)
tests/conftest.py:10: error: Cannot find module named 'backlog'
tests/conftest.py:10: note: (Perhaps setting MYPYPATH or using the "--ignore-missing-imports" flag would help)
```

Modeled after `pytest-pylint`:
https://github.com/carsongee/pytest-pylint/blob/7381a938cd61deedde0a771c592449e71d3ac25e/pytest_pylint.py#L207-L209
