### PR TITLE
Register the custom marker

### DIFF
--- a/pytest_mypy.py
+++ b/pytest_mypy.py
@@ -32,6 +32,10 @@ def pytest_collect_file(path, parent):
         return MypyItem(path, parent, mypy_config)
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "mypy: mark tests to be checked by mypy.")
+
+
 class MypyError(Exception):
     """
     An error caught by mypy, e.g a type checker violation


### PR DESCRIPTION
The 'mypy' marker was introduced in #18. However, pytest doesn't know
about it and emits a warning.

This commit registers the marker to remove the warning, as documented by
pytest upstream:

https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers

Fixes #25