### PR TITLE
Restrict the version of mypy used by the plugin with Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ setup(
     description='Mypy static type checker plugin for Pytest',
     long_description=read('README.rst'),
     py_modules=['pytest_mypy'],
-    install_requires=['pytest>=2.9.2', 'mypy~=0.570'],
+    install_requires=[
+        'pytest>=2.9.2',
+        'mypy>=0.570,<0.650; python_version<"3.5"',
+        'mypy~=0.570; python_version>="3.5"',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',


### PR DESCRIPTION
Fix #27 

In addition to fixing #27, this version should be pinned so that a downstream project pinned to a particular version of `pytest-mypy` can more easily get reproducible test runs (i.e. a run doesn't fail because a newer version of Mypy was released).