### PR TITLE
Test supported versions of mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
     long_description=read('README.rst'),
     py_modules=['pytest_mypy'],
     install_requires=[
-        'pytest>=2.9.0,<5.0.0',
+        'pytest>=2.9,<4.7; python_version<"3.5"',
+        'pytest>=2.9; python_version>="3.5"',
         'mypy>=0.570,<0.650; python_version<"3.5"',
         'mypy~=0.570; python_version>="3.5"',
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
     long_description=read('README.rst'),
     py_modules=['pytest_mypy'],
     install_requires=[
-        'pytest>=2.9,<4.7; python_version<"3.5"',
-        'pytest>=2.9; python_version>="3.5"',
+        'pytest>=2.8,<4.7; python_version<"3.5"',
+        'pytest>=2.8; python_version>="3.5"',
         'mypy>=0.570,<0.700; python_version<"3.5"',
         'mypy>=0.570; python_version>="3.5"',
     ],

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
     install_requires=[
         'pytest>=2.9,<4.7; python_version<"3.5"',
         'pytest>=2.9; python_version>="3.5"',
-        'mypy>=0.570,<0.650; python_version<"3.5"',
-        'mypy~=0.570; python_version>="3.5"',
+        'mypy>=0.570,<0.700; python_version<"3.5"',
+        'mypy>=0.570; python_version>="3.5"',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -7,7 +7,7 @@ def test_mypy_success(testdir):
             assert myfunc(12)
     ''')
 
-    result = testdir.runpytest('--mypy', '-v')
+    result = testdir.runpytest_subprocess('--mypy', '-v')
 
     assert result.ret == 0
 
@@ -21,7 +21,7 @@ def test_mypy_error(testdir):
             assert myfunc(12)
     ''')
 
-    result = testdir.runpytest('--mypy', '-v')
+    result = testdir.runpytest_subprocess('--mypy', '-v')
 
     result.stdout.fnmatch_lines([
         'test_mypy_error.py:2: error: Incompatible return value*',

--- a/tox.ini
+++ b/tox.ini
@@ -3,30 +3,32 @@
 min_version = 3.7.0
 isolated_build = true
 envlist =
-    py{34, 35, 36}-pytest{2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5}-mypy{0.570, 0.580, 0.590, 0.600, 0.610, 0.620, 0.630, 0.641, 0.650, 0.660, 0.670}
-    py{35, 36}-pytest{2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5}-mypy{0.700, 0.701}
+    py{34, 35, 36}-pytest{2.9, 3.0, 3.x, 4.0, 4.x}-mypy{0.570, 0.580, 0.590, 0.600, 0.610, 0.620, 0.630, 0.641, 0.650, 0.660, 0.670}
+    py{35, 36}-pytest{2.9, 3.0, 3.x, 4.0, 4.x}-mypy{0.700, 0.701}
     flake8
 
 [testenv]
 deps =
-    pytest2.9:  pytest ~= 2.9.0
-    pytest3.0:  pytest ~= 3.0.0
-    pytest3.1:  pytest ~= 3.1.0
-    pytest3.2:  pytest ~= 3.2.0
-    pytest3.3:  pytest ~= 3.3.0
-    pytest3.4:  pytest ~= 3.4.0
-    pytest3.5:  pytest ~= 3.5.0
-    pytest3.6:  pytest ~= 3.6.0
-    pytest3.7:  pytest ~= 3.7.0
-    pytest3.8:  pytest ~= 3.8.0
-    pytest3.9:  pytest ~= 3.9.0
+    pytest2.9: pytest ~= 2.9.0
+    pytest3.0: pytest ~= 3.0.0
+    pytest3.1: pytest ~= 3.1.0
+    pytest3.2: pytest ~= 3.2.0
+    pytest3.3: pytest ~= 3.3.0
+    pytest3.4: pytest ~= 3.4.0
+    pytest3.5: pytest ~= 3.5.0
+    pytest3.6: pytest ~= 3.6.0
+    pytest3.7: pytest ~= 3.7.0
+    pytest3.8: pytest ~= 3.8.0
+    pytest3.9: pytest ~= 3.9.0
     pytest3.10: pytest ~= 3.10.0
-    pytest4.0:  pytest ~= 4.0.0
-    pytest4.1:  pytest ~= 4.1.0
-    pytest4.2:  pytest ~= 4.2.0
-    pytest4.3:  pytest ~= 4.3.0
-    pytest4.4:  pytest ~= 4.4.0
-    pytest4.5:  pytest ~= 4.5.0
+    pytest3.x: pytest ~= 3.0
+    pytest4.0: pytest ~= 4.0.0
+    pytest4.1: pytest ~= 4.1.0
+    pytest4.2: pytest ~= 4.2.0
+    pytest4.3: pytest ~= 4.3.0
+    pytest4.4: pytest ~= 4.4.0
+    pytest4.5: pytest ~= 4.5.0
+    pytest4.x: pytest ~= 4.0
     mypy0.570: mypy == 0.570
     mypy0.580: mypy == 0.580
     mypy0.590: mypy == 0.590

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 [tox]
 min_version = 3.7.0
 isolated_build = true
-envlist = py{34, 35, 36}-pytest{2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5}, flake8
+envlist =
+    py{34, 35, 36}-pytest{2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5}-mypy{0.570, 0.580, 0.590, 0.600, 0.610, 0.620, 0.630, 0.641, 0.650, 0.660, 0.670}
+    py{35, 36}-pytest{2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5}-mypy{0.700, 0.701}
+    flake8
 
 [testenv]
 deps =
@@ -24,6 +27,19 @@ deps =
     pytest4.3:  pytest ~= 4.3.0
     pytest4.4:  pytest ~= 4.4.0
     pytest4.5:  pytest ~= 4.5.0
+    mypy0.570: mypy == 0.570
+    mypy0.580: mypy == 0.580
+    mypy0.590: mypy == 0.590
+    mypy0.600: mypy == 0.600
+    mypy0.610: mypy == 0.610
+    mypy0.620: mypy == 0.620
+    mypy0.630: mypy == 0.630
+    mypy0.641: mypy == 0.641
+    mypy0.650: mypy == 0.650
+    mypy0.660: mypy == 0.660
+    mypy0.670: mypy == 0.670
+    mypy0.700: mypy == 0.700
+    mypy0.701: mypy == 0.701
 commands = py.test {posargs:tests}
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@
 min_version = 3.7.0
 isolated_build = true
 envlist =
-    py{34, 35, 36}-pytest{2.9, 3.0, 3.x, 4.0, 4.x}-mypy{0.570, 0.580, 0.590, 0.600, 0.610, 0.620, 0.630, 0.641, 0.650, 0.660, 0.670}
-    py{35, 36}-pytest{2.9, 3.0, 3.x, 4.0, 4.x}-mypy{0.700, 0.701}
+    py{34, 35, 36}-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x}-mypy{0.570, 0.580, 0.590, 0.600, 0.610, 0.620, 0.630, 0.641, 0.650, 0.660, 0.670}
+    py{35, 36}-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x}-mypy{0.700, 0.701}
     flake8
 
 [testenv]
 deps =
-    pytest2.9: pytest ~= 2.9.0
+    pytest2.8: pytest ~= 2.8.0
+    pytest2.x: pytest ~= 2.8
     pytest3.0: pytest ~= 3.0.0
     pytest3.1: pytest ~= 3.1.0
     pytest3.2: pytest ~= 3.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     pytest4.3: pytest ~= 4.3.0
     pytest4.4: pytest ~= 4.4.0
     pytest4.5: pytest ~= 4.5.0
+    pytest4.6: pytest ~= 4.6.0
     pytest4.x: pytest ~= 4.0
     mypy0.570: mypy == 0.570
     mypy0.580: mypy == 0.580


### PR DESCRIPTION
Resolve #27

- > [The pytest 4.6 series will be the last to support Python 2.7 and 3.4](https://docs.pytest.org/en/latest/py27-py34-deprecation.html)
- As of `mypy-0.700`,
  > [You can no longer run mypy using Python 3.4, since Python 3.4 has reached its end of life. ](https://mypy-lang.blogspot.com/2019/04/mypy-0700-released-up-to-4x-faster.html)
- #27 appears to be a test issue only as the tests do not fail when `runpytest_subprocess` is used instead of just `runpytest`.
- After adding supported mypy versions to the Tox matrix, [the entire matrix cannot be tested by Travis before the build is killed](https://travis-ci.com/dmtucker/pytest-mypy/builds/114854010). To mitigate this, we can reduce default testing to key versions that theoretically should provide comparable coverage (assuming SemVer is strictly observed).
- The plugin supports Pytest 2.8 even though it was never explicitly made to, so we can add that to the list of supported versions.
- Pytest 4.6 has been released, so we can add that as an option for testing.
