### PR TITLE
Call mypy once and parse its output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,13 @@ You can enable pytest-mypy with the ``--mypy`` flag:
     $ py.test --mypy test_*.py
 
 Mypy supports `reading configuration settings <http://mypy.readthedocs.io/en/latest/config_file.html>`_ from a ``mypy.ini`` file.
-This is currently the only way to configure mypy through pytest-mypy.
-In the future pytest-mypy may offer a passthrough for command line
-options.
+Alternatively, the plugin can be configured in a ``conftest.py`` to invoke mypy with extra options:
+
+.. code-block:: python
+
+    def pytest_configure(config):
+        plugin = config.pluginmanager.getplugin('mypy')
+        plugin.mypy_argv.append('--check-untyped-defs')
 
 You can restrict your test run to only perform mypy checks and not any other tests by using the `-m` option:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0
+* Run mypy once per session instead of once per file.
+* Stop passing --incremental (which mypy now defaults to).
+* Support configuring the plugin in a conftest.py.
+
 ## 0.3.3
 * Register `mypy` marker.
 * Add a PEP-518 [build-system]

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -4,6 +4,9 @@ import pytest
 import mypy.api
 
 
+mypy_argv = []
+
+
 def pytest_addoption(parser):
     """Add options for enabling and running mypy."""
     group = parser.getgroup('mypy')
@@ -17,25 +20,66 @@ def pytest_addoption(parser):
 
 def pytest_collect_file(path, parent):
     """Create a MypyItem for every file mypy should run on."""
-    config = parent.config
-    mypy_config = []
-
-    if config.option.mypy_ignore_missing_imports:
-        mypy_config.append("--ignore-missing-imports")
-
     if path.ext == '.py' and any([
-            config.option.mypy,
-            config.option.mypy_ignore_missing_imports,
+            parent.config.option.mypy,
+            parent.config.option.mypy_ignore_missing_imports,
     ]):
-        return MypyItem(path, parent, mypy_config)
+        return MypyItem(path, parent)
+    return None
+
+
+def pytest_runtestloop(session):
+    """Run mypy on collected MypyItems, then sort the output."""
+    mypy_items = {
+        item.mypy_path(): item
+        for item in session.items
+        if isinstance(item, MypyItem)
+    }
+    if mypy_items:
+
+        terminal = session.config.pluginmanager.getplugin('terminalreporter')
+        terminal.write(
+            '\nRunning {command} on {file_count} files... '.format(
+                command=' '.join(['mypy'] + mypy_argv),
+                file_count=len(mypy_items),
+            ),
+        )
+        stdout, stderr, status = mypy.api.run(
+            mypy_argv + [str(item.fspath) for item in mypy_items.values()],
+        )
+        terminal.write('done with status {status}\n'.format(status=status))
+
+        unmatched_lines = []
+        for line in stdout.split('\n'):
+            if not line:
+                continue
+            mypy_path, _, error = line.partition(':')
+            try:
+                item = mypy_items[mypy_path]
+            except KeyError:
+                unmatched_lines.append(line)
+            else:
+                item.mypy_errors.append(error)
+        if any(unmatched_lines):
+            terminal.write_line('\n'.join(unmatched_lines), red=True)
+
+        if stderr:
+            terminal.write_line(stderr, red=True)
 
 
 def pytest_configure(config):
-    """Register a custom marker for MypyItems."""
+    """
+    Register a custom marker for MypyItems,
+    and configure the plugin based on the CLI.
+    """
     config.addinivalue_line(
-        "markers",
-        "mypy: mark tests to be checked by mypy.",
+        'markers',
+        '{marker}: mark tests to be checked by mypy.'.format(
+            marker=MypyItem.MARKER,
+        ),
     )
+    if config.getoption('--mypy-ignore-missing-imports'):
+        mypy_argv.append('--ignore-missing-imports')
 
 
 class MypyError(Exception):
@@ -50,34 +94,24 @@ class MypyItem(pytest.Item, pytest.File):
 
     """A File that Mypy Runs On."""
 
-    def __init__(self, path, parent, config):
-        super().__init__(path, parent)
-        self.path = path
-        self.mypy_config = config
-        self.add_marker("mypy")
+    MARKER = 'mypy'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_marker(self.MARKER)
+        self.mypy_errors = []
+
+    def mypy_path(self):
+        return self.fspath.relto(self.config.rootdir)
 
     def reportinfo(self):
         """Produce a heading for the test report."""
-        return self.fspath, None, ' '.join(['mypy', self.name])
+        return self.fspath, None, self.mypy_path()
 
     def runtest(self):
-        """
-        Run mypy on the given file.
-        """
-
-        # Construct a fake command line argv and let mypy do its
-        # own options parsing.
-        mypy_argv = [
-            str(self.path),
-            '--incremental',
-        ]
-
-        mypy_argv += self.mypy_config
-
-        stdout, _, _ = mypy.api.run(args=mypy_argv)
-
-        if stdout:
-            raise MypyError(stdout)
+        """Raise an exception if mypy found errors for this item."""
+        if self.mypy_errors:
+            raise MypyError('\n'.join(self.mypy_errors))
 
     def repr_failure(self, excinfo):
         """

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -102,6 +102,7 @@ class MypyItem(pytest.Item, pytest.File):
         self.mypy_errors = []
 
     def mypy_path(self):
+        """Get the path that is expected to show up in Mypy results."""
         return self.fspath.relto(self.config.rootdir)
 
     def reportinfo(self):

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -107,3 +107,14 @@ def test_mypy_unmatched_stdout(testdir):
     '''.format(stdout=stdout))
     result = testdir.runpytest_subprocess('--mypy')
     result.stdout.fnmatch_lines([stdout])
+
+
+def test_api_mypy_argv(testdir):
+    """Ensure that the plugin can be configured in a conftest.py."""
+    testdir.makepyfile(conftest='''
+        def pytest_configure(config):
+            plugin = config.pluginmanager.getplugin('mypy')
+            plugin.mypy_argv.append('--version')
+    ''')
+    result = testdir.runpytest_subprocess('--mypy')
+    assert result.ret == 0

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -22,7 +22,7 @@ def test_mypy_error(testdir):
     result = testdir.runpytest_subprocess('--mypy')
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines([
-        'test_mypy_error.py:2: error: Incompatible return value*',
+        '2: error: Incompatible return value*',
     ])
     assert result.ret != 0
 
@@ -38,7 +38,7 @@ def test_mypy_ignore_missings_imports(testdir):
     result = testdir.runpytest_subprocess('--mypy')
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines([
-        '*1: error: Cannot find module named*',
+        '1: error: Cannot find module named*',
     ])
     assert result.ret != 0
     result = testdir.runpytest_subprocess('--mypy-ignore-missing-imports')
@@ -77,3 +77,33 @@ def test_non_mypy_error(testdir):
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(['*' + message])
     assert result.ret != 0
+
+
+def test_mypy_stderr(testdir):
+    """Verify that stderr from mypy is printed."""
+    stderr = 'This is stderr from mypy.'
+    testdir.makepyfile(conftest='''
+        import mypy.api
+
+        def _patched_run(*args, **kwargs):
+            return '', '{stderr}', 1
+
+        mypy.api.run = _patched_run
+    '''.format(stderr=stderr))
+    result = testdir.runpytest_subprocess('--mypy')
+    result.stdout.fnmatch_lines([stderr])
+
+
+def test_mypy_unmatched_stdout(testdir):
+    """Verify that unexpected output on stdout from mypy is printed."""
+    stdout = 'This is unexpected output on stdout from mypy.'
+    testdir.makepyfile(conftest='''
+        import mypy.api
+
+        def _patched_run(*args, **kwargs):
+            return '{stdout}', '', 1
+
+        mypy.api.run = _patched_run
+    '''.format(stdout=stdout))
+    result = testdir.runpytest_subprocess('--mypy')
+    result.stdout.fnmatch_lines([stdout])


### PR DESCRIPTION
Fix #21 
Resolve #20 

To test performance, I downloaded [`requests3`](https://github.com/kennethreitz/requests3/tree/40aaff930106a73c9e19d40ff675b2e8efd62810) and ran this script (on https://github.com/dbader/pytest-mypy/commit/11d6c23f661bb4725c627a9e0821c9d5a18aa25e):
``` bash
pytest_mypy="$HOME/Projects/pytest-mypy"
tox_env='py37-pytest4.6-mypy0.711'
branch='run-once'

run_test () {
    log="$1"
    cd ~/Projects/requests3
    "$pytest_mypy/.tox/$tox_env/bin/pip" install rfc3986 trio h11 pyOpenSSL twisted . 1>/dev/null 2>&1
    rm -rf .mypy_cache/
    time "$pytest_mypy/.tox/$tox_env/bin/pytest" --mypy -m mypy 1>"$pytest_mypy/$log.log" 2>&1
}

cd "$pytest_mypy"
git checkout dbader/master
tox -e "$tox_env" -r 1>/dev/null 2>&1
run_test master

cd "$pytest_mypy"
git checkout "$branch"
tox -e "$tox_env" -r 1>/dev/null 2>&1
run_test "$branch"
```
- [master.log](https://github.com/dbader/pytest-mypy/files/3384954/master.log)
- [run-once.log](https://github.com/dbader/pytest-mypy/files/3384955/run-once.log)


These were the results on my 2010 MBP:
```
HEAD is now at 9c29d20 Merge pull request #40 from dmtucker/mypy

real	2m43.380s
user	2m36.195s
sys	0m4.667s
Previous HEAD position was 9c29d20 Merge pull request #40 from dmtucker/mypy
Switched to branch 'run-once'
Your branch is up to date with 'dmtucker/run-once'.

real	0m13.370s
user	0m12.225s
sys	0m0.876s
run_test "$branch"
```

Note that the results are actually different too:
- `master`
  > 90 failed, 241 deselected, 26 error in 159.09 seconds
- `run-once`
  > 42 failed, 48 passed, 241 deselected, 26 error in 12.14 seconds

This is because of "failures" like this (where the results are not relevant to the tested file):
```
________________________________ mypy server.py ________________________________
tests/__init__.py:6: error: No library stub file for module 'urllib3'
tests/__init__.py:6: note: (Stub files are from https://github.com/python/typeshed)
tests/__init__.py:7: error: No library stub file for module 'urllib3.exceptions'
```