### PR TITLE
Add ::MYPY annotation to test nodeid

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -89,7 +89,10 @@ class MypyItem(pytest.Item, pytest.File):
     MARKER = 'mypy'
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(MypyItem, self).__init__(*args, **kwargs)
+        if hasattr(self, "_nodeid"):
+            self._nodeid += "::MYPY"
+
         self.add_marker(self.MARKER)
         self.mypy_errors = []
 


### PR DESCRIPTION
This is to be consistent with pytest-black and pytest-flake8 as well as
be descriptive when running:

```bash
pytest -v --tb=no --lf
```

To get a list of last failed test node IDs.

References:

 - https://github.com/shopkeep/pytest-black/blob/master/pytest_black.py#L45
 - https://github.com/tholo/pytest-flake8/blob/master/pytest_flake8.py#L90

Annotate nodeid where it is a valid property of pytest.Item

TODO:
 - [ ] Add test to get 100% code coverage for pytest <= 3.0
       - It seems `pytest.Item` didn't always have `self._nodeid` across the tox testing matrix of pytest.
       - https://docs.pytest.org/en/2.9.2/example/index.html 
       - Pytest 2.9.2 release commit: https://github.com/pytest-dev/pytest/tree/978bb190a14d04634dffa1018dce2a5ead404efa

Parking this for now but hints appreciated to close the gap.

Also appreciate if this is not in line with where the project is going and you want to close on principle.

Thanks for your time in triage and review.