### PR TITLE
Do not overlap python_version requirements - fix for poetry package manager

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'pytest>=2.8,<4.7; python_version<"3.5"',
         'pytest>=2.8; python_version>="3.5"',
         'mypy>=0.570,<0.700; python_version<"3.5"',
-        'mypy>=0.570; python_version>="3.5"',
+        'mypy>=0.570; python_version>="3.5" and python_version<"3.8.0b1"',
         'mypy>=0.701; python_version>="3.8.0b1"',
     ],
     classifiers=[


### PR DESCRIPTION
This was noticed while trying to install the package using poetry and encountering an issue [like this](https://github.com/sdispater/poetry/issues/1238).

I've tested installing with this change and it doesn't have the infinite recursion issue.