### PR TITLE
Pin attrs for Pytest 4.0 - 4.2 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,11 @@ deps =
     pytest3.9: pytest ~= 3.9.0
     pytest3.10: pytest ~= 3.10.0
     pytest3.x: pytest ~= 3.0
+    pytest4.0: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
     pytest4.0: pytest ~= 4.0.0
+    pytest4.1: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
     pytest4.1: pytest ~= 4.1.0
+    pytest4.2: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
     pytest4.2: pytest ~= 4.2.0
     pytest4.3: pytest ~= 4.3.0
     pytest4.4: pytest ~= 4.4.0


### PR DESCRIPTION
Fix #55 