### PR TITLE
Fix tests for mypy>=0.750

### DIFF
--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -38,7 +38,7 @@ def test_mypy_ignore_missings_imports(testdir):
     result = testdir.runpytest_subprocess('--mypy')
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines([
-        '1: error: Cannot find module named*',
+        "1: error: Cannot find *module named 'pytest_mypy'",
     ])
     assert result.ret != 0
     result = testdir.runpytest_subprocess('--mypy-ignore-missing-imports')

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,8 @@ deps =
     mypy0.72: mypy >= 0.720, < 0.730
     mypy0.73: mypy >= 0.730, < 0.740
     mypy0.74: mypy >= 0.740, < 0.750
+    mypy0.75: mypy >= 0.750, < 0.760
+    mypy0.76: mypy >= 0.760, < 0.770
     mypy0.7x: mypy >= 0.700, < 0.800
 
     pytest-cov ~= 2.5.1


### PR DESCRIPTION
The expected error message for missing imports changed in mypy 0.750: https://github.com/python/mypy/pull/7698