### PR TITLE
Add a configurable name to MypyItem node IDs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     python_requires='~=3.4',
     install_requires=[
         'filelock>=3.0',
-        'pytest>=2.8,<4.7; python_version<"3.5"',
-        'pytest>=2.8; python_version>="3.5"',
+        'pytest>=3.5,<4.7; python_version<"3.5"',
+        'pytest>=3.5; python_version>="3.5"',
         'mypy>=0.500,<0.700; python_version<"3.5"',
         'mypy>=0.500; python_version>="3.5" and python_version<"3.8"',
         'mypy>=0.700; python_version>="3.8"',

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -10,6 +10,7 @@ import mypy.api
 
 
 mypy_argv = []
+nodeid_name = 'mypy'
 
 
 def pytest_addoption(parser):
@@ -77,7 +78,14 @@ def pytest_collect_file(path, parent):
             parent.config.option.mypy,
             parent.config.option.mypy_ignore_missing_imports,
     ]):
-        return MypyItem(path, parent)
+        item = MypyItem(path, parent)
+        if nodeid_name:
+            item = MypyItem(
+                path,
+                parent,
+                nodeid='::'.join([item.nodeid, nodeid_name]),
+            )
+        return item
     return None
 
 

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -145,6 +145,19 @@ def test_api_mypy_argv(testdir, xdist_args):
     assert result.ret == 0
 
 
+def test_api_nodeid_name(testdir, xdist_args):
+    """Ensure that the plugin can be configured in a conftest.py."""
+    nodeid_name = 'UnmistakableNodeIDName'
+    testdir.makepyfile(conftest='''
+        def pytest_configure(config):
+            plugin = config.pluginmanager.getplugin('mypy')
+            plugin.nodeid_name = '{}'
+    '''.format(nodeid_name))
+    result = testdir.runpytest_subprocess('--mypy', '--verbose', *xdist_args)
+    result.stdout.fnmatch_lines(['*conftest.py::' + nodeid_name + '*'])
+    assert result.ret == 0
+
+
 def test_pytest_collection_modifyitems(testdir, xdist_args):
     testdir.makepyfile(conftest='''
         def pytest_collection_modifyitems(session, config, items):

--- a/tox.ini
+++ b/tox.ini
@@ -3,31 +3,15 @@
 min_version = 3.7.0
 isolated_build = true
 envlist =
-    py34-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x}-mypy{0.50, 0.5x, 0.60, 0.6x}
-    py35-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
-    py36-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
-    py37-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
-    py38-pytest{2.8, 2.x, 3.0, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}
+    py34-pytest{3.5, 3.x, 4.0, 4.x}-mypy{0.50, 0.5x, 0.60, 0.6x}
+    py35-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
+    py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
+    py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
+    py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}
     flake8
 
 [testenv]
 deps =
-    pytest2.8: pytest ~= 2.8.0
-    pytest2.8: pytest-xdist < 1.18.0
-    pytest2.x: pytest ~= 2.8
-    pytest2.x: pytest-xdist < 1.18.0
-    pytest3.0: pytest ~= 3.0.0
-    pytest3.0: pytest-xdist < 1.19.0
-    pytest3.1: pytest ~= 3.1.0
-    pytest3.1: pytest-xdist < 1.19.0
-    pytest3.2: pytest ~= 3.2.0
-    pytest3.2: pytest-xdist < 1.19.0
-    pytest3.3: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/3223
-    pytest3.3: pytest ~= 3.3.0
-    pytest3.3: pytest-xdist < 1.19.0
-    pytest3.4: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/3223
-    pytest3.4: pytest ~= 3.4.0
-    pytest3.4: pytest-xdist < 1.19.0
     pytest3.5: pytest ~= 3.5.0
     pytest3.5: pytest-xdist < 1.19.0
     pytest3.6: pytest ~= 3.6.0
@@ -40,7 +24,7 @@ deps =
     pytest3.9: pytest-xdist < 1.28.0
     pytest3.10: pytest ~= 3.10.0
     pytest3.10: pytest-xdist < 1.28.0
-    pytest3.x: pytest ~= 3.0
+    pytest3.x: pytest ~= 3.5
     pytest3.x: pytest-xdist < 1.28.0
     pytest4.0: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
     pytest4.0: pytest ~= 4.0.0


### PR DESCRIPTION
Resolve #74 

I started with #45 to ensure the effort @neozenith put into this work is acknowledged 😊 

The main concern with that PR was primarily the use of the private attribute `_nodeid` and secondarily a forced changed (to absolute paths) of the default node ID. This deals with those by using the `nodeid` kwarg to `pytest.Item` and re-creating a `MypyItem` that will have a name added to the node ID (basing off of the original `MypyItem`'s node ID).

The `nodeid` kwarg is not available until Pytest 3.5, so **this drops support for `pytest >= 2.8, < 3.5`**. That has the convenient side-effect of fixing #46 (again), which was reintroduced by the extra testing in #73.

Lastly, the new node ID name is configurable in the same manner as `mypy_argv`:
``` python
import mypy.version  # beware: not a public API

def pytest_configure(config):
    """Add the mypy version to the node ID of MypyItems."""
    plugin = config.pluginmanager.getplugin('mypy')
    plugin.nodeid_name += mypy.version.__version__
```
```
============================= test session starts ==============================
platform darwin -- Python 3.8.0, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /Users/dmtucker/Projects/pytest-mypy/venv/bin/python
cachedir: .pytest_cache
Using --randomly-seed=1581720682
rootdir: /Users/dmtucker/Projects/pytest-mypy
plugins: xdist-1.29.0, cov-2.5.1, forked-1.1.3, randomly-2.1.1, mypy-0.4.2
collecting ... collected 1 item

conftest.py::mypy0.761 PASSED                                       [100%]
===================================== mypy =====================================

Success: no issues found in 1 source file
============================== 1 passed in 0.20s ===============================
```

Unfortunately, `MypyItem`s (still) cannot be selected by their node ID.
I suspect that is not supported by Pytest (as opposed to something this project is lacking).