### PR TITLE
Deploy from Travis CI with Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
   on:
     repo: dbader/pytest-mypy
     tags: true
-    python: '3.4'
+    python: '3.8'
 before_cache:
 - rm -rf $HOME/.cache/pip/log
 cache:


### PR DESCRIPTION
Travis CI no longer supports deployment with Python 3.4:
https://travis-ci.org/dbader/pytest-mypy/jobs/654157543#L788