### PR TITLE
Inject a test that checks the mypy exit status

### DIFF
--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -14,29 +14,29 @@ def xdist_args(request):
     return ['-n', 'auto'] if request.param else []
 
 
-@pytest.mark.parametrize('test_count', [1, 2])
-def test_mypy_success(testdir, test_count, xdist_args):
+@pytest.mark.parametrize('pyfile_count', [1, 2])
+def test_mypy_success(testdir, pyfile_count, xdist_args):
     """Verify that running on a module with no type errors passes."""
     testdir.makepyfile(
         **{
-            'test_' + str(test_i): '''
-                def myfunc(x: int) -> int:
+            'pyfile_' + str(pyfile_i): '''
+                def pyfunc(x: int) -> int:
                     return x * 2
             '''
-            for test_i in range(test_count)
+            for pyfile_i in range(pyfile_count)
         }
     )
     result = testdir.runpytest_subprocess(*xdist_args)
     result.assert_outcomes()
     result = testdir.runpytest_subprocess('--mypy', *xdist_args)
-    result.assert_outcomes(passed=test_count)
+    result.assert_outcomes(passed=pyfile_count)
     assert result.ret == 0
 
 
 def test_mypy_error(testdir, xdist_args):
     """Verify that running on a module with type errors fails."""
     testdir.makepyfile('''
-        def myfunc(x: int) -> str:
+        def pyfunc(x: int) -> str:
             return x * 2
     ''')
     result = testdir.runpytest_subprocess(*xdist_args)
@@ -178,7 +178,7 @@ def test_pytest_collection_modifyitems(testdir, xdist_args):
                 items.pop(mypy_item_i)
     ''')
     testdir.makepyfile('''
-        def myfunc(x: int) -> str:
+        def pyfunc(x: int) -> str:
             return x * 2
 
         def test_pass():

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -167,6 +167,11 @@ def test_api_nodeid_name(testdir, xdist_args):
 
 
 def test_pytest_collection_modifyitems(testdir, xdist_args):
+    """
+    Verify that collected files which are removed in a
+    pytest_collection_modifyitems implementation are not
+    checked by mypy.
+    """
     testdir.makepyfile(conftest='''
         def pytest_collection_modifyitems(session, config, items):
             plugin = config.pluginmanager.getplugin('mypy')

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -98,11 +98,11 @@ def test_non_mypy_error(testdir, xdist_args):
         def pytest_configure(config):
             plugin = config.pluginmanager.getplugin('mypy')
 
-            class PatchedMypyItem(plugin.MypyItem):
+            class PatchedMypyFileItem(plugin.MypyFileItem):
                 def runtest(self):
                     raise Exception('{message}')
 
-            plugin.MypyItem = PatchedMypyItem
+            plugin.MypyFileItem = PatchedMypyFileItem
     '''.format(message=message))
     result = testdir.runpytest_subprocess(*xdist_args)
     result.assert_outcomes()
@@ -178,7 +178,7 @@ def test_pytest_collection_modifyitems(testdir, xdist_args):
             for mypy_item_i in reversed([
                     i
                     for i, item in enumerate(items)
-                    if isinstance(item, plugin.MypyItem)
+                    if isinstance(item, plugin.MypyFileItem)
             ]):
                 items.pop(mypy_item_i)
     ''')

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ deps =
 
     pytest-cov ~= 2.5.1
     pytest-randomly ~= 2.1.1
-commands = py.test -p no:mypy -n auto --cov pytest_mypy --cov-fail-under 100 --cov-report term-missing {posargs}
+commands = py.test -p no:mypy --cov pytest_mypy --cov-fail-under 100 --cov-report term-missing {posargs:-n auto} tests
 
 [testenv:static]
 deps =


### PR DESCRIPTION
Fix #69 

From [the Mypy docs](https://mypy.readthedocs.io/en/latest/running_mypy.html#follow-imports),
> Mypy is designed to [doggedly follow all imports](https://mypy.readthedocs.io/en/latest/running_mypy.html#finding-imports), even if the imported module is not a file you explicitly wanted mypy to check.

This is problematic because, if `mypy` reports errors in a file `pytest` didn't collect, `pytest-mypy` has no `MypyItem` (now `MypyFileItem`) to match the errors to, and, if there are no other errors to report, the plugin may not force [the correct `pytest` exit status](https://docs.pytest.org/en/latest/reference.html#_pytest.config.ExitCode.TESTS_FAILED)!

To remedy that, this injects a new `MypyStatusItem` which just checks the `mypy` exit status and fails if it's nonzero. _This means that an extra test will run for every `--mypy` invocation._ Also, both `MypyStatusItem` and the new `MypyFileItem` inherit from `MypyItem`, **so some existing checks that currently check for `MypyItem`s may need to be updated to check for `MypyFileItem`s**.