### PR TITLE
Fix an issue where PEP 561 .pyi stub files are ignored

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -86,9 +86,7 @@ def pytest_collect_file(path, parent):
         # .pyi file with the same name already exists;
         # pytest will complain about duplicate modules otherwise
         path_pyi = str(path) + 'i'  # i.e. a .pyi instead of a .py file
-        if os.path.isfile(path_pyi):
-            return None
-        else:
+        if not os.path.isfile(path_pyi):
             return MypyFile.from_parent(parent=parent, fspath=path)
     return None
 

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -79,14 +79,10 @@ def pytest_collect_file(path, parent):
             parent.config.option.mypy,
             parent.config.option.mypy_ignore_missing_imports,
     ]):
-        if path.ext == '.pyi':
-            return MypyFile.from_parent(parent=parent, fspath=path)
-
         # Do not create MypyFile instance for a .py file if a
         # .pyi file with the same name already exists;
         # pytest will complain about duplicate modules otherwise
-        path_pyi = str(path) + 'i'  # i.e. a .pyi instead of a .py file
-        if not os.path.isfile(path_pyi):
+        if path.ext == '.pyi' or not path.new(ext='.pyi').isfile():
             return MypyFile.from_parent(parent=parent, fspath=path)
     return None
 

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -79,7 +79,17 @@ def pytest_collect_file(path, parent):
             parent.config.option.mypy,
             parent.config.option.mypy_ignore_missing_imports,
     ]):
-        return MypyFile.from_parent(parent=parent, fspath=path)
+        if path.ext == '.pyi':
+            return MypyFile.from_parent(parent=parent, fspath=path)
+
+        # Do not create MypyFile instance for a .py file if a
+        # .pyi file with the same name already exists;
+        # pytest will complain about duplicate modules otherwise
+        path_pyi = str(path) + 'i'  # i.e. a .pyi instead of a .py file
+        if os.path.isfile(path_pyi):
+            return None
+        else:
+            return MypyFile.from_parent(parent=parent, fspath=path)
     return None
 
 

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -75,7 +75,7 @@ def pytest_configure(config):
 
 def pytest_collect_file(path, parent):
     """Create a MypyFileItem for every file mypy should run on."""
-    if path.ext == '.py' and any([
+    if path.ext in {'.py', '.pyi'} and any([
             parent.config.option.mypy,
             parent.config.option.mypy_ignore_missing_imports,
     ]):


### PR DESCRIPTION
Previously the in [PEP 561](https://www.python.org/dev/peps/pep-0561/#partial-stub-packages) introduced .pyi stub files were ignored by `pytest-mypy`, in contrast with `mypy` itself which handles them just fine.
This pull requests addresses aforementioned issue.

See also: https://mypy.readthedocs.io/en/stable/stubs.html