### PR TITLE
Drop py34, add GitHub Actions and a tox env for publishing

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,15 @@
+name: Validation
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: python -m pip install --upgrade tox-gh-actions
+    - run: python -m tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-- '3.4'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,8 @@
 dist: xenial
 language: python
-python:
-- '3.5'
-- '3.6'
-- '3.7'
-- '3.8'
-install: pip install 'tox-travis ~= 0.12.0'
-script: tox
-jobs:
-  include:
-  - name: Static Analysis
-    python: '3.8'
-    script: tox -e static
+python: '3.8'
+install: pip install tox
+script: tox -e publish
 deploy:
   provider: pypi
   user: __token__
@@ -23,8 +14,3 @@ deploy:
     repo: dbader/pytest-mypy
     tags: true
     python: '3.8'
-before_cache:
-- rm -rf $HOME/.cache/pip/log
-cache:
-  directories:
-  - "$HOME/.cache/pip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ['setuptools ~= 43.0.0', 'setuptools-scm ~= 3.5.0', 'wheel ~= 0.33.6']
+requires = ['setuptools ~= 45.2.0', 'setuptools-scm ~= 3.5.0', 'wheel ~= 0.34.0']
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -29,16 +29,14 @@ setup(
         os.path.splitext(os.path.basename(path))[0]
         for path in glob.glob('src/*.py')
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     setup_requires=[
         'setuptools-scm>=3.5',
     ],
     install_requires=[
         'filelock>=3.0',
-        'pytest>=3.5,<4.7; python_version<"3.5"',
-        'pytest>=3.5; python_version>="3.5"',
-        'mypy>=0.500,<0.700; python_version<"3.5"',
-        'mypy>=0.500; python_version>="3.5" and python_version<"3.8"',
+        'pytest>=3.5',
+        'mypy>=0.500; python_version<"3.8"',
         'mypy>=0.700; python_version>="3.8"',
     ],
     classifiers=[
@@ -48,7 +46,6 @@ setup(
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -255,8 +255,7 @@ def test_mypy_indirect(testdir, xdist_args):
     testdir.makepyfile(good='''
         import bad
     ''')
-    xdist_args.append('good.py')  # Nothing may come after xdist_args in py34.
-    result = testdir.runpytest_subprocess('--mypy', *xdist_args)
+    result = testdir.runpytest_subprocess('--mypy', *xdist_args, 'good.py')
     assert result.ret != 0
 
 
@@ -283,7 +282,7 @@ def test_mypy_indirect_inject(testdir, xdist_args):
                 plugin.MypyFileItem(py.path.local('good.py'), session),
             )
     ''')
-    testdir.mkdir('empty')
-    xdist_args.append('empty')  # Nothing may come after xdist_args in py34.
-    result = testdir.runpytest_subprocess('--mypy', *xdist_args)
+    name = 'empty'
+    testdir.mkdir(name)
+    result = testdir.runpytest_subprocess('--mypy', *xdist_args, name)
     assert result.ret != 0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 min_version = 3.7.0
 isolated_build = true
 envlist =
-    py34-pytest{3.5, 3.x, 4.0, 4.x}-mypy{0.50, 0.5x, 0.60, 0.6x}
     py35-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
     py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
     py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,13 @@ envlist =
     py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}
     static
 
+[gh-actions]
+python =
+    3.5: py35-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
+    3.6: py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
+    3.7: py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
+    3.8: py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}, static
+
 [testenv]
 deps =
     pytest3.5: pytest ~= 3.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
     py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
     py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}
+    publish
     static
 
 [gh-actions]
@@ -14,7 +15,7 @@ python =
     3.5: py35-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
     3.6: py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
     3.7: py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x}
-    3.8: py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}, static
+    3.8: py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x}-mypy{0.71, 0.7x}, publish, static
 
 [testenv]
 deps =
@@ -87,6 +88,15 @@ deps =
     pytest-cov ~= 2.5.1
     pytest-randomly ~= 2.1.1
 commands = py.test -p no:mypy --cov pytest_mypy --cov-fail-under 100 --cov-report term-missing {posargs:-n auto} tests
+
+[testenv:publish]
+passenv = TWINE_*
+deps =
+    pep517 ~= 0.8.0
+    twine ~= 3.2.0
+commands =
+    {envpython} -m pep517.build --out-dir {distdir} .
+    twine {posargs:check} {distdir}/*
 
 [testenv:static]
 deps =


### PR DESCRIPTION
Close #46 

[py34 has reached EOL](https://devguide.python.org/devcycle/#end-of-life-branches), and [`tox-gh-actions` does not support it](https://github.com/ymyzk/tox-gh-actions/blob/4b51ab6879d90d78362b98b4fd118b79d6b57808/setup.cfg#L40).

Dropping support should not affect the vast majority of active users.
In the last 30 days, py34 accounted for only 0.003% of `pytest-mypy` downloads:
```
$ pypinfo pytest-mypy pyversion
Served from cache: False
Data processed: 117.47 GiB
Data billed: 117.47 GiB
Estimated cost: $0.58

| python_version | download_count |
| -------------- | -------------- |
| 3.7            |         56,011 |
| 3.8            |         18,070 |
| 3.6            |         15,508 |
| 3.9            |            678 |
| 3.5            |            324 |
| 3.10           |             90 |
| 2.7            |             28 |
| 3.4            |              3 |
| Total          |         90,712 |
```

Switching to GitHub Actions should more permanently resolve #46; however, we can't use it to replace Travis CI entirely without @dbader's help (because admin privileges are required to set repo [Secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets), which we would need for PyPI creds e.g. https://github.com/dmtucker/backlog/blob/10701deae4fde379d281808184c3c715b53a980a/.github/workflows/publication.yml#L15-L16)