### PR TITLE
Enable custom error formatting

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -14,6 +14,14 @@ mypy_argv = []
 nodeid_name = 'mypy'
 
 
+def default_file_error_formatter(item, results, errors):
+    """Create a string to be displayed when mypy finds errors in a file."""
+    return '\n'.join(errors)
+
+
+file_error_formatter = default_file_error_formatter
+
+
 def pytest_addoption(parser):
     """Add options for enabling and running mypy."""
     group = parser.getgroup('mypy')
@@ -158,7 +166,7 @@ class MypyFileItem(MypyItem):
         abspath = os.path.abspath(str(self.fspath))
         errors = results['abspath_errors'].get(abspath)
         if errors:
-            raise MypyError('\n'.join(errors))
+            raise MypyError(file_error_formatter(self, results, errors))
 
     def reportinfo(self):
         """Produce a heading for the test report."""


### PR DESCRIPTION
This adds a new plugin attribute (`file_error_formatter`) that defines a callable which is invoked when `mypy` finds errors in a file.
Here is an example (similar to the new test) of how it can be used to resolve #90 (cc: @markusschmaus, @jduprey):
``` python
import py


def custom_file_error_formatter(item, results, errors):
    """Include the file path before each reported error."""
    return '\n'.join(
        '{path}:{error}'.format(
            path=py.path.local('.').bestrelpath(item.fspath),
            error=error,
        )   
        for error in errors
    )


def pytest_configure(config):
    plugin = config.pluginmanager.getplugin('mypy')
    plugin.file_error_formatter = custom_file_error_formatter
```