### PR TITLE
Fix test_mypy_indirect_inject

### DIFF
--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -279,7 +279,10 @@ def test_mypy_indirect_inject(testdir, xdist_args):
         def pytest_collection_modifyitems(session, config, items):
             plugin = config.pluginmanager.getplugin('mypy')
             items.append(
-                plugin.MypyFileItem(py.path.local('good.py'), session),
+                plugin.MypyFileItem.from_parent(
+                    parent=session,
+                    name=str(py.path.local('good.py')),
+                ),
             )
     ''')
     name = 'empty'


### PR DESCRIPTION
I discovered this in a local branch that makes use of [Pytest's `ExitCode` structure](https://docs.pytest.org/en/5.0.0/reference.html#pytest-exitcode) in the tests:
```
------------------------------------------------ Captured stdout call ------------------------------------------------
running: /home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/bin/python -mpytest --basetemp=/tmp/pytest-of-dtux/pytest-27/popen-gw4/test_mypy_indirect_inject0/runpytest-0 --mypy empty
     in: /tmp/pytest-of-dtux/pytest-27/popen-gw4/test_mypy_indirect_inject0
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
Using --randomly-seed=1471697750
rootdir: /tmp/pytest-of-dtux/pytest-27/popen-gw4/test_mypy_indirect_inject0
plugins: forked-1.3.0, mypy-0.6.3.dev14+g572994e.d20200804, cov-2.10.0, xdist-1.34.0, randomly-3.4.1
collected 0 items
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/_pytest/main.py", line 240, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/_pytest/main.py", line 295, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/_pytest/main.py", line 306, in pytest_collection
INTERNALERROR>     session.perform_collect()
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/_pytest/main.py", line 518, in perform_collect
INTERNALERROR>     hook.pytest_collection_modifyitems(
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/tmp/pytest-of-dtux/pytest-27/popen-gw4/test_mypy_indirect_inject0/conftest.py", line 8, in pytest_collection_modifyitems
INTERNALERROR>     plugin.MypyFileItem(py.path.local('good.py'), session),
INTERNALERROR>   File "/home/dtux/Projects/pytest-mypy/.tox/py38-pytest6.x-mypy0.7x/lib/python3.8/site-packages/_pytest/nodes.py", line 95, in __call__
INTERNALERROR>     warnings.warn(NODE_USE_FROM_PARENT.format(name=self.__name__), stacklevel=2)
INTERNALERROR> pytest.PytestDeprecationWarning: Direct construction of MypyFileItem has been deprecated, please use MypyFileItem.from_parent.
INTERNALERROR> See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.

============================ no tests ran in 0.08s =============================
```
The test only checks for: https://github.com/dbader/pytest-mypy/blob/6f8f19a33f266a3b420abc3478133f1341e22837/tests/test_pytest_mypy.py#L288
`test_mypy_indirect_inject` has been passing for the wrong reason.