### PR TITLE
Drop support for pytest<4.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         "attrs>=19.0",
         "filelock>=3.0",
-        "pytest>=3.5",
+        "pytest>=4.6",
         'mypy>=0.500; python_version<"3.8"',
         'mypy>=0.700; python_version>="3.8" and python_version<"3.9"',
         'mypy>=0.780; python_version>="3.9"',

--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -87,10 +87,6 @@ def pytest_configure(config):
 
             config.pluginmanager.register(_MypyXdistPlugin())
 
-    # pytest_terminal_summary cannot accept config before pytest 4.2.
-    global _pytest_terminal_summary_config
-    _pytest_terminal_summary_config = config
-
     config.addinivalue_line(
         "markers",
         "{marker}: mark tests to be checked by mypy.".format(marker=MypyItem.MARKER),
@@ -292,9 +288,8 @@ class MypyError(Exception):
     """
 
 
-def pytest_terminal_summary(terminalreporter):
+def pytest_terminal_summary(terminalreporter, config):
     """Report stderr and unrecognized lines from stdout."""
-    config = _pytest_terminal_summary_config
     try:
         with open(config._mypy_results_path, mode="r") as results_f:
             results = MypyResults.load(results_f)

--- a/tox.ini
+++ b/tox.ini
@@ -3,103 +3,29 @@
 minversion = 3.20
 isolated_build = true
 envlist =
-    py35-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.71, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    py39-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.78, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    py35-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    py36-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    py37-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    py38-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.71, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    py39-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.78, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
     publish
     static
 
 [gh-actions]
 python =
-    3.5: py35-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    3.6: py36-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    3.7: py37-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
-    3.8: py38-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.71, 0.7x, 0.80, 0.8x, 0.90, 0.9x}, publish, static
-    3.9: py39-pytest{3.5, 3.x, 4.0, 4.x, 5.0, 5.x, 6.0, 6.x}-mypy{0.78, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    3.5: py35-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    3.6: py36-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    3.7: py37-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.50, 0.5x, 0.60, 0.6x, 0.70, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
+    3.8: py38-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.71, 0.7x, 0.80, 0.8x, 0.90, 0.9x}, publish, static
+    3.9: py39-pytest{4.6, 5.0, 5.x, 6.0, 6.x}-mypy{0.78, 0.7x, 0.80, 0.8x, 0.90, 0.9x}
 
 [testenv]
 deps =
-    pytest3.5: pytest ~= 3.5.0
-    pytest3.5: pytest-cov ~= 2.5.1
-    pytest3.5: pytest-randomly ~= 2.1.1
-    pytest3.5: pytest-xdist < 1.19.0
-    pytest3.6: pytest ~= 3.6.0
-    pytest3.6: pytest-cov ~= 2.5.1
-    pytest3.6: pytest-randomly ~= 2.1.1
-    pytest3.6: pytest-xdist < 1.28.0
-    pytest3.7: pytest ~= 3.7.0
-    pytest3.7: pytest-cov ~= 2.5.1
-    pytest3.7: pytest-randomly ~= 2.1.1
-    pytest3.7: pytest-xdist < 1.28.0
-    pytest3.8: pytest ~= 3.8.0
-    pytest3.8: pytest-cov ~= 2.5.1
-    pytest3.8: pytest-randomly ~= 2.1.1
-    pytest3.8: pytest-xdist < 1.28.0
-    pytest3.9: pytest ~= 3.9.0
-    pytest3.9: pytest-cov ~= 2.5.1
-    pytest3.9: pytest-randomly ~= 2.1.1
-    pytest3.9: pytest-xdist < 1.28.0
-    pytest3.10: pytest ~= 3.10.0
-    pytest3.10: pytest-cov ~= 2.5.1
-    pytest3.10: pytest-randomly ~= 2.1.1
-    pytest3.10: pytest-xdist < 1.28.0
-    pytest3.x: pytest ~= 3.5
-    pytest3.x: pytest-cov ~= 2.5.1
-    pytest3.x: pytest-randomly ~= 2.1.1
-    pytest3.x: pytest-xdist < 1.28.0
-    pytest4.0: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
-    pytest4.0: pytest ~= 4.0.0
-    pytest4.0: pytest-cov ~= 2.5.1
-    pytest4.0: pytest-randomly ~= 2.1.1
-    pytest4.0: pytest-xdist < 1.28.0
-    pytest4.1: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
-    pytest4.1: pytest ~= 4.1.0
-    pytest4.1: pytest-cov ~= 2.5.1
-    pytest4.1: pytest-randomly ~= 2.1.1
-    pytest4.1: pytest-xdist < 1.28.0
-    pytest4.2: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
-    pytest4.2: pytest-cov ~= 2.5.1
-    pytest4.2: pytest-randomly ~= 2.1.1
-    pytest4.2: pytest ~= 4.2.0
-    pytest4.2: pytest-xdist < 1.28.0
-    pytest4.3: pytest ~= 4.3.0
-    pytest4.3: pytest-cov ~= 2.5.1
-    pytest4.3: pytest-randomly ~= 2.1.1
-    pytest4.3: pytest-xdist < 1.28.0
-    pytest4.4: pytest ~= 4.4.0
-    pytest4.4: pytest-cov ~= 2.5.1
-    pytest4.4: pytest-randomly ~= 2.1.1
-    pytest4.4: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
-    pytest4.5: pytest ~= 4.5.0
-    pytest4.5: pytest-cov ~= 2.5.1
-    pytest4.5: pytest-randomly ~= 2.1.1
-    pytest4.5: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest4.6: pytest ~= 4.6.0
-    pytest4.6: pytest-cov ~= 2.5.1
-    pytest4.6: pytest-randomly ~= 2.1.1
-    pytest4.6: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
-    pytest4.x: pytest ~= 4.0
-    pytest4.x: pytest-cov ~= 2.5.1
-    pytest4.x: pytest-randomly ~= 2.1.1
-    pytest4.x: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest5.0: pytest ~= 5.0.0
-    pytest5.0: pytest-cov ~= 2.5.1
-    pytest5.0: pytest-randomly ~= 2.1.1
-    pytest5.0: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest5.x: pytest ~= 5.0
-    pytest5.x: pytest-cov ~= 2.5.1
-    pytest5.x: pytest-randomly ~= 2.1.1
-    pytest5.x: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest6.0: pytest ~= 6.0.0
-    pytest6.0: pytest-cov ~= 2.10
-    pytest6.0: pytest-randomly ~= 3.4
-    pytest6.0: pytest-xdist ~= 2.0
     pytest6.x: pytest ~= 6.0
-    pytest6.x: pytest-cov ~= 2.10
-    pytest6.x: pytest-randomly ~= 3.4
-    pytest6.x: pytest-xdist ~= 2.0
     mypy0.50: mypy >= 0.500, < 0.510
     mypy0.51: mypy >= 0.510, < 0.520
     mypy0.52: mypy >= 0.520, < 0.530
@@ -138,8 +64,11 @@ deps =
     mypy0.9x: mypy >= 0.900, <= 0.999
 
     pexpect ~= 4.8.0
+    pytest-cov ~= 2.10
+    pytest-randomly ~= 3.4
+    pytest-xdist ~= 1.34
 
-commands = py.test -p no:mypy {posargs:--cov pytest_mypy --cov-fail-under 100 --cov-report term-missing -n auto}
+commands = pytest -p no:mypy {posargs:--cov pytest_mypy --cov-fail-under 100 --cov-report term-missing -n auto}
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
- There is a product code improvement that can be made by requiring `pytest>=4.2`.
- Pytest 4.x is no longer supported (except `4.6.x`, which is community supported):
  ![image](https://user-images.githubusercontent.com/1817814/122168553-474ed480-ce31-11eb-9cca-55cfe7968e35.png)
  - A project that uses `pytest>=4.2,<4.6` would probably not have too hard a time upgrading to 4.6. 