### PR TITLE
Add long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     url='https://github.com/dbader/pytest-mypy',
     description='Mypy static type checker plugin for Pytest',
     long_description=read('README.rst'),
+    long_description_content_type='text/x-rst',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[


### PR DESCRIPTION
This resolves `twine` warnings:
```
publish run-test: commands[1] | twine check '/home/dtux/Projects/pytest-mypy/.tox/dist/*'
Checking /home/dtux/Projects/pytest-mypy/.tox/dist/pytest_mypy-0.6.3.dev15+g44a726c-py3-none-any.whl: PASSED, with warnings
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking /home/dtux/Projects/pytest-mypy/.tox/dist/pytest-mypy-0.6.3.dev15+g44a726c.tar.gz: PASSED, with warnings
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
```
After:
```
publish run-test: commands[1] | twine check '/home/dtux/Projects/pytest-mypy/.tox/dist/*'
Checking /home/dtux/Projects/pytest-mypy/.tox/dist/pytest_mypy-0.6.3.dev15+g44a726c.d20200815-py3-none-any.whl: PASSED
Checking /home/dtux/Projects/pytest-mypy/.tox/dist/pytest-mypy-0.6.3.dev15+g44a726c.d20200815.tar.gz: PASSED
```