### PR TITLE
Add pytest-xdist 2.0.0 compatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,46 +20,84 @@ python =
 [testenv]
 deps =
     pytest3.5: pytest ~= 3.5.0
+    pytest3.5: pytest-cov ~= 2.5.1
+    pytest3.5: pytest-randomly ~= 2.1.1
     pytest3.5: pytest-xdist < 1.19.0
     pytest3.6: pytest ~= 3.6.0
+    pytest3.6: pytest-cov ~= 2.5.1
+    pytest3.6: pytest-randomly ~= 2.1.1
     pytest3.6: pytest-xdist < 1.28.0
     pytest3.7: pytest ~= 3.7.0
+    pytest3.7: pytest-cov ~= 2.5.1
+    pytest3.7: pytest-randomly ~= 2.1.1
     pytest3.7: pytest-xdist < 1.28.0
     pytest3.8: pytest ~= 3.8.0
+    pytest3.8: pytest-cov ~= 2.5.1
+    pytest3.8: pytest-randomly ~= 2.1.1
     pytest3.8: pytest-xdist < 1.28.0
     pytest3.9: pytest ~= 3.9.0
+    pytest3.9: pytest-cov ~= 2.5.1
+    pytest3.9: pytest-randomly ~= 2.1.1
     pytest3.9: pytest-xdist < 1.28.0
     pytest3.10: pytest ~= 3.10.0
+    pytest3.10: pytest-cov ~= 2.5.1
+    pytest3.10: pytest-randomly ~= 2.1.1
     pytest3.10: pytest-xdist < 1.28.0
     pytest3.x: pytest ~= 3.5
+    pytest3.x: pytest-cov ~= 2.5.1
+    pytest3.x: pytest-randomly ~= 2.1.1
     pytest3.x: pytest-xdist < 1.28.0
     pytest4.0: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
     pytest4.0: pytest ~= 4.0.0
+    pytest4.0: pytest-cov ~= 2.5.1
+    pytest4.0: pytest-randomly ~= 2.1.1
     pytest4.0: pytest-xdist < 1.28.0
     pytest4.1: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
     pytest4.1: pytest ~= 4.1.0
+    pytest4.1: pytest-cov ~= 2.5.1
+    pytest4.1: pytest-randomly ~= 2.1.1
     pytest4.1: pytest-xdist < 1.28.0
     pytest4.2: attrs < 19.2.0  # https://github.com/pytest-dev/pytest/issues/5900
+    pytest4.2: pytest-cov ~= 2.5.1
+    pytest4.2: pytest-randomly ~= 2.1.1
     pytest4.2: pytest ~= 4.2.0
     pytest4.2: pytest-xdist < 1.28.0
     pytest4.3: pytest ~= 4.3.0
+    pytest4.3: pytest-cov ~= 2.5.1
+    pytest4.3: pytest-randomly ~= 2.1.1
     pytest4.3: pytest-xdist < 1.28.0
     pytest4.4: pytest ~= 4.4.0
+    pytest4.4: pytest-cov ~= 2.5.1
+    pytest4.4: pytest-randomly ~= 2.1.1
     pytest4.4: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest4.5: pytest ~= 4.5.0
+    pytest4.5: pytest-cov ~= 2.5.1
+    pytest4.5: pytest-randomly ~= 2.1.1
     pytest4.5: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest4.6: pytest ~= 4.6.0
+    pytest4.6: pytest-cov ~= 2.5.1
+    pytest4.6: pytest-randomly ~= 2.1.1
     pytest4.6: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest4.x: pytest ~= 4.0
+    pytest4.x: pytest-cov ~= 2.5.1
+    pytest4.x: pytest-randomly ~= 2.1.1
     pytest4.x: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest5.0: pytest ~= 5.0.0
+    pytest5.0: pytest-cov ~= 2.5.1
+    pytest5.0: pytest-randomly ~= 2.1.1
     pytest5.0: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest5.x: pytest ~= 5.0
+    pytest5.x: pytest-cov ~= 2.5.1
+    pytest5.x: pytest-randomly ~= 2.1.1
     pytest5.x: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
     pytest6.0: pytest ~= 6.0.0
-    pytest6.0: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
+    pytest6.0: pytest-cov ~= 2.10
+    pytest6.0: pytest-randomly ~= 3.4
+    pytest6.0: pytest-xdist ~= 2.0
     pytest6.x: pytest ~= 6.0
-    pytest6.x: pytest-xdist ~= 1.0, < 1.30.0  # https://github.com/pytest-dev/pytest-xdist/issues/472
+    pytest6.x: pytest-cov ~= 2.10
+    pytest6.x: pytest-randomly ~= 3.4
+    pytest6.x: pytest-xdist ~= 2.0
     mypy0.50: mypy >= 0.500, < 0.510
     mypy0.51: mypy >= 0.510, < 0.520
     mypy0.52: mypy >= 0.520, < 0.530
@@ -91,8 +129,6 @@ deps =
     mypy0.78: mypy >= 0.780, < 0.790
     mypy0.7x: mypy >= 0.700, < 0.800
 
-    pytest-cov ~= 2.5.1
-    pytest-randomly ~= 2.1.1
 commands = py.test -p no:mypy --cov pytest_mypy --cov-fail-under 100 --cov-report term-missing {posargs:-n auto} tests
 
 [testenv:publish]


### PR DESCRIPTION

Attempt fetching the `workerinput` config node attribute using both the
new and the old name.

Adjust tox version to test the new xdist with the new pytest only.