### PR TITLE
Stop injecting MypyStatusItem in pytest_collection_modifyitems to fix --looponfail

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -125,26 +125,16 @@ class MypyFile(pytest.File):
     def collect(self):
         """Create a MypyFileItem for the File."""
         yield MypyFileItem.from_parent(parent=self, name=nodeid_name)
-
-
-@pytest.hookimpl(hookwrapper=True, trylast=True)
-def pytest_collection_modifyitems(session, config, items):
-    """
-    Add a MypyStatusItem if any MypyFileItems were collected.
-
-    Since mypy might check files that were not collected,
-    pytest could pass even though mypy failed!
-    To prevent that, add an explicit check for the mypy exit status.
-
-    This should execute as late as possible to avoid missing any
-    MypyFileItems injected by other pytest_collection_modifyitems
-    implementations.
-    """
-    yield
-    if any(isinstance(item, MypyFileItem) for item in items):
-        items.append(
-            MypyStatusItem.from_parent(parent=session, name=nodeid_name),
-        )
+        # Since mypy might check files that were not collected,
+        # pytest could pass even though mypy failed!
+        # To prevent that, add an explicit check for the mypy exit status.
+        if not any(
+                isinstance(item, MypyStatusItem) for item in self.session.items
+        ):
+            yield MypyStatusItem.from_parent(
+                parent=self,
+                name=nodeid_name + "-status",
+            )
 
 
 class MypyItem(pytest.Item):

--- a/tox.ini
+++ b/tox.ini
@@ -132,6 +132,8 @@ deps =
     mypy0.79: mypy >= 0.790, < 0.800
     mypy0.7x: mypy >= 0.700, < 0.800
 
+    pexpect ~= 4.8.0
+
 commands = py.test -p no:mypy --cov pytest_mypy --cov-fail-under 100 --cov-report term-missing {posargs:-n auto} tests
 
 [testenv:publish]


### PR DESCRIPTION
Resolve #85 

This behaves much better.
- Using `--looponfail` should no longer crash or run duplicates.
- The status check can now be run by node ID on any file (though, it may not be a really _useful_ thing to do).
- **Injecting _just_ `MypyFileItem`s in a `pytest_collection_modifyitems` hook no longer implies a status check.**
  If you want that, you need to inject a `MypyStatusItem` too.
- Likewise, the `MypyStatusItem` is now present in `items` in `pytest_collection_modifyitems`.
  Remove it to ignore `mypy` errors in uncollected modules.