### PR TITLE
Implement MypyItem.collect for pytest < 6.0

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -145,6 +145,13 @@ class MypyItem(pytest.Item):
         super().__init__(*args, **kwargs)
         self.add_marker(self.MARKER)
 
+    def collect(self):
+        """
+        Partially work around https://github.com/pytest-dev/pytest/issues/8016
+        for pytest < 6.0 with --looponfail.
+        """
+        yield self
+
     @classmethod
     def from_parent(cls, *args, **kwargs):
         """Override from_parent for compatibility."""


### PR DESCRIPTION
Resolve #115 

- This partially works around https://github.com/pytest-dev/pytest/issues/8016 for 3.10 <= pytest < 6.0.
  - It avoids #115, but we cannot prevent taking [a code path that only collects 1 `Item`](https://github.com/pytest-dev/pytest/blob/c934de6e1bb65ec99d3d35827ad56d9c6081f429/src/_pytest/main.py#L587).
- The workaround does not help with 6.0 <= pytest < 6.2 (because [an assertion](https://github.com/pytest-dev/pytest/blob/1142d138e3801372efabc1199290d6840a1ca8a2/src/_pytest/main.py#L777) fails first).
- The issue is truly fixed in pytest 6.2 (by https://github.com/pytest-dev/pytest/pull/8022).