### PR TITLE
Add stdout and stderr to mypy status error

### DIFF
--- a/src/pytest_mypy.py
+++ b/src/pytest_mypy.py
@@ -222,8 +222,12 @@ class MypyStatusItem(MypyItem):
         results = MypyResults.from_session(self.session)
         if results.status:
             raise MypyError(
-                "mypy exited with status {status}.".format(
+                "mypy exited with status {status}.\n"
+                "stdout: {stdout}\n"
+                "stderr: {stderr}".format(
                     status=results.status,
+                    stdout=results.stdout,
+                    stderr=results.stderr,
                 ),
             )
 


### PR DESCRIPTION
Relates to #120 : adds further information to the error message so that the mentioned issue can be more easily debugged (e.g. on CI environments)