### PR TITLE
Remove MypyWarning

### DIFF
--- a/src/pytest_mypy/__init__.py
+++ b/src/pytest_mypy/__init__.py
@@ -234,7 +234,10 @@ class MypyFileItem(MypyItem):
         """Raise an exception if mypy found errors for this item."""
         results = MypyResults.from_session(self.session)
         abspath = str(self.path.resolve())
-        errors = results.abspath_errors.get(abspath)
+        errors = [
+            error.partition(":")[2].strip()
+            for error in results.abspath_errors.get(abspath, [])
+        ]
         if errors:
             if not all(
                 error.partition(":")[2].partition(":")[0].strip() == "note"
@@ -327,7 +330,7 @@ class MypyResults:
             path, _, error = line.partition(":")
             abspath = str(Path(path).resolve())
             try:
-                abspath_errors[abspath].append(error)
+                abspath_errors[abspath].append(line)
             except KeyError:
                 unmatched_lines.append(line)
 

--- a/src/pytest_mypy/__init__.py
+++ b/src/pytest_mypy/__init__.py
@@ -391,15 +391,17 @@ class MypyControllerPlugin:
         except FileNotFoundError:
             # No MypyItems executed.
             return
-        if config.option.mypy_xfail or results.unmatched_stdout or results.stderr:
-            terminalreporter.section(terminal_summary_title)
+        if not results.stdout and not results.stderr:
+            return
+        terminalreporter.section(terminal_summary_title)
+        if results.stdout:
             if config.option.mypy_xfail:
                 terminalreporter.write(results.stdout)
             elif results.unmatched_stdout:
                 color = {"red": True} if results.status else {"green": True}
                 terminalreporter.write_line(results.unmatched_stdout, **color)
-            if results.stderr:
-                terminalreporter.write_line(results.stderr, yellow=True)
+        if results.stderr:
+            terminalreporter.write_line(results.stderr, yellow=True)
 
     def pytest_unconfigure(self, config: pytest.Config) -> None:
         """Clean up the mypy results path."""

--- a/src/pytest_mypy/__init__.py
+++ b/src/pytest_mypy/__init__.py
@@ -233,7 +233,7 @@ class MypyFileItem(MypyItem):
     def runtest(self) -> None:
         """Raise an exception if mypy found errors for this item."""
         results = MypyResults.from_session(self.session)
-        abspath = str(self.path.absolute())
+        abspath = str(self.path.resolve())
         errors = results.abspath_errors.get(abspath)
         if errors:
             if not all(
@@ -312,7 +312,7 @@ class MypyResults:
         if opts is None:
             opts = mypy_argv[:]
         abspath_errors = {
-            str(path.absolute()): [] for path in paths
+            str(path.resolve()): [] for path in paths
         }  # type: MypyResults._abspath_errors_type
 
         cwd = Path.cwd()
@@ -325,7 +325,7 @@ class MypyResults:
             if not line:
                 continue
             path, _, error = line.partition(":")
-            abspath = str(Path(path).absolute())
+            abspath = str(Path(path).resolve())
             try:
                 abspath_errors[abspath].append(error)
             except KeyError:

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -552,7 +552,7 @@ def test_py_typed(testdir):
 
 def test_mypy_no_status_check(testdir, xdist_args):
     """Verify that --mypy-no-status-check disables MypyStatusItem collection."""
-    testdir.makepyfile(thon="one: int = 1")
+    testdir.makepyfile("one: int = 1")
     result = testdir.runpytest_subprocess("--mypy", *xdist_args)
     mypy_file_checks = 1
     mypy_status_check = 1
@@ -565,7 +565,7 @@ def test_mypy_no_status_check(testdir, xdist_args):
 
 def test_mypy_xfail_passes(testdir, xdist_args):
     """Verify that --mypy-xfail passes passes."""
-    testdir.makepyfile(thon="one: int = 1")
+    testdir.makepyfile("one: int = 1")
     result = testdir.runpytest_subprocess("--mypy", *xdist_args)
     mypy_file_checks = 1
     mypy_status_check = 1
@@ -578,7 +578,7 @@ def test_mypy_xfail_passes(testdir, xdist_args):
 
 def test_mypy_xfail_xfails(testdir, xdist_args):
     """Verify that --mypy-xfail xfails failures."""
-    testdir.makepyfile(thon="one: str = 1")
+    testdir.makepyfile("one: str = 1")
     result = testdir.runpytest_subprocess("--mypy", *xdist_args)
     mypy_file_checks = 1
     mypy_status_check = 1

--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -130,7 +130,9 @@ def test_mypy_annotation_unchecked(testdir, xdist_args, tmp_path, monkeypatch):
     mypy_checks = mypy_file_checks + mypy_status_check
     outcomes = {"passed": mypy_checks}
     result.assert_outcomes(**outcomes)
-    result.stdout.fnmatch_lines(["*MypyWarning*"])
+    result.stdout.fnmatch_lines(
+        ["*:2: note: By default the bodies of untyped functions are not checked*"]
+    )
     assert result.ret == pytest.ExitCode.OK
 
 


### PR DESCRIPTION
Warnings are for developers, but `MypyWarning` (from #146) was being used to communicate with users.
This replaces that with extra reporting in the terminal summary.