### PR TITLE
Add --mypy-report-style

### DIFF
--- a/tests/test_pytest_mypy.py
+++ b/tests/test_pytest_mypy.py
@@ -399,24 +399,19 @@ def test_mypy_indirect(testdir, xdist_args, module_name):
     assert result.ret == pytest.ExitCode.TESTS_FAILED
 
 
-def test_api_error_formatter(testdir, xdist_args):
-    """Ensure that the plugin can be configured in a conftest.py."""
+def test_api_file_error_formatter(testdir, xdist_args):
+    """Ensure that the file_error_formatter can be replaced in a conftest.py."""
     testdir.makepyfile(
         bad="""
             def pyfunc(x: int) -> str:
                 return x * 2
         """,
     )
+    file_error = "UnmistakableFileError"
     testdir.makepyfile(
-        conftest="""
+        conftest=f"""
             def custom_file_error_formatter(item, results, errors):
-                return '\\n'.join(
-                    '{path}:{error}'.format(
-                        path=item.fspath,
-                        error=error,
-                    )
-                    for error in errors
-                )
+                return '{file_error}'
 
             def pytest_configure(config):
                 plugin = config.pluginmanager.getplugin('mypy')
@@ -424,7 +419,7 @@ def test_api_error_formatter(testdir, xdist_args):
         """,
     )
     result = testdir.runpytest_subprocess("--mypy", *xdist_args)
-    result.stdout.fnmatch_lines(["*/bad.py:2: error: Incompatible return value*"])
+    result.stdout.fnmatch_lines([f"*{file_error}*"])
     assert result.ret == pytest.ExitCode.TESTS_FAILED
 
 


### PR DESCRIPTION
Resolve #90 

```console
$ venv/bin/pytest --mypy-report-style no-path demo/bad.py 
====================== test session starts =======================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
Using --randomly-seed=827345869
rootdir: /home/dtux/Projects/pytest-mypy
configfile: tox.ini
plugins: mypy-0.10.4.dev92+g7e232a1, cov-4.1.0, randomly-3.16.0
collected 2 items                                                

demo/bad.py FF                                             [100%]

============================ FAILURES ============================
_______________________ [mypy] demo/bad.py _______________________
1: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
__________________________ test session __________________________
mypy exited with status 1.
============================== mypy ==============================
Found 1 error in 1 file (checked 1 source file)
==================== short test summary info =====================
FAILED demo/bad.py::mypy1.15.0
FAILED demo/bad.py::mypy1.15.0-status
======================= 2 failed in 0.27s ========================
```
- Note: `no-path` style is still the default.
```console
$ venv/bin/pytest --mypy-report-style mypy demo/bad.py 
====================== test session starts =======================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
Using --randomly-seed=373067107
rootdir: /home/dtux/Projects/pytest-mypy
configfile: tox.ini
plugins: mypy-0.10.4.dev92+g7e232a1, cov-4.1.0, randomly-3.16.0
collected 2 items                                                

demo/bad.py FF                                             [100%]

============================ FAILURES ============================
__________________________ test session __________________________
mypy exited with status 1.
_______________________ [mypy] demo/bad.py _______________________
demo/bad.py:1: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
============================== mypy ==============================
Found 1 error in 1 file (checked 1 source file)
==================== short test summary info =====================
FAILED demo/bad.py::mypy1.15.0-status
FAILED demo/bad.py::mypy1.15.0
======================= 2 failed in 0.27s ========================
```
- `mypy` style returns the lines unaltered (i.e. exactly how `mypy` created them).