### PR TITLE
Drop support for Python 3.8 & 3.9

### DIFF
--- a/.github/workflows/publication.yaml
+++ b/.github/workflows/publication.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: "3.9"
     - run: python -m pip install --upgrade tox-gh-actions
     - env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/publication.yaml
+++ b/.github/workflows/publication.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - run: python -m pip install --upgrade tox-gh-actions
     - env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Testing",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "filelock>=3.0",
     "mypy>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -29,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Testing",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "filelock>=3.0",
     "mypy>=1.0",

--- a/src/pytest_mypy/__init__.py
+++ b/src/pytest_mypy/__init__.py
@@ -34,7 +34,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     from xdist.workermanage import WorkerController  # type: ignore
 
 
-@dataclass(frozen=True)  # compat python < 3.10 (kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class MypyConfigStash:
     """Plugin data stored in the pytest.Config stash."""
 
@@ -299,7 +299,7 @@ class MypyStatusItem(MypyItem):
             raise MypyError(f"mypy exited with status {results.status}.")
 
 
-@dataclass(frozen=True)  # compat python < 3.10 (kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class MypyResults:
     """Parsed results from Mypy."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 minversion = 4.4
 isolated_build = true
 envlist =
-    py39-pytest{7.0, 7.x, 8.0, 8.x}-mypy{1.0, 1.x}-xdist{2.0, 2.x, 3.0, 3.x}
     py310-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
     py311-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
     py312-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
@@ -14,7 +13,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.9: py39-pytest{7.0, 7.x, 8.0, 8.x}-mypy{1.0, 1.x}-xdist{2.0, 2.x, 3.0, 3.x}
     3.10: py310-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
     3.11: py311-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
     3.12: py312-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}, static, publish

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 minversion = 4.4
 isolated_build = true
 envlist =
-    py38-pytest{7.0, 7.x, 8.0, 8.x}-mypy{1.0, 1.x}-xdist{2.0, 2.x, 3.0, 3.x}
     py39-pytest{7.0, 7.x, 8.0, 8.x}-mypy{1.0, 1.x}-xdist{2.0, 2.x, 3.0, 3.x}
     py310-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
     py311-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
@@ -15,7 +14,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38-pytest{7.0, 7.x, 8.0, 8.x}-mypy{1.0, 1.x}-xdist{2.0, 2.x, 3.0, 3.x}
     3.9: py39-pytest{7.0, 7.x, 8.0, 8.x}-mypy{1.0, 1.x}-xdist{2.0, 2.x, 3.0, 3.x}
     3.10: py310-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}
     3.11: py311-pytest{7.0, 7.x, 8.0, 8.x, 9.0, 9.x}-mypy{1.0, 1.x, 2.0, 2.x}-xdist{2.0, 2.x, 3.0, 3.x}


### PR DESCRIPTION
3.9 went EOL in October 2025.